### PR TITLE
Fix the Deploy to Render button

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This example triggers a GitHub Action workflow when a deploy ended webhook is re
 ## Deploy to Render
 
 1. Use the button below to deploy to Render </br>
-<a href="https://render.com/deploy?repo=https://github.com/render-examples/twingate-example/tree/main"><img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render"></a>
+<a href="https://render.com/deploy?repo=https://github.com/render-examples/webhook-github-action/tree/main"><img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render"></a>
 
 2. Follow [instructions](https://render.com/docs/webhooks) to create a webhook with the URL from your service and `/webhook` path
 3. Follow [instructions](https://render.com/docs/api#1-create-an-api-key) to create a Render API Key


### PR DESCRIPTION
- Currently the button points to another repo. Let's point it at this repo